### PR TITLE
Memory-optimize randnet_param_tests code

### DIFF
--- a/functions/randnet_calculator_memOpt.m
+++ b/functions/randnet_calculator_memOpt.m
@@ -1,0 +1,91 @@
+function [spikeMat, conns] = randnet_calculator_memOpt(parameters, seed, network, V_m)
+    %_________
+    % ABOUT: This function produces identical results as
+    % randnet_calculator, but the only variables it saves is V_m.
+    % Use randnet_calculator for simulations where you want to analyze
+    % other variables. 
+    % Use randnet_calculator for simulations where you only need V_m and
+    % wanted to reduce memory usage. 
+    % 
+    % The script test_randnet_calculator tests that randnet_calcualtor and
+    % randnet_calculator_memOpt produce the same V_m and conns
+    %
+    % Note: another option is to have a single simulation function with a 
+    % flag inside the loop that can save the variable vectors at each time
+    % step. But this if statement slows the simulation by ~3%
+    
+    
+    %Set the random number generator seed
+    rng(seed)
+    
+
+    %Create Storage Variables (single time-step, updated each increment)
+    G_sra = zeros(parameters.n,1); %refractory conductance for each neuron at each timestep (S)
+    G_syn_I_E = zeros(parameters.n,1); %conductance for pre-inhib to post-excit (S)
+    G_syn_E_E = zeros(parameters.n,1); %conductance for pre-excit to post-excit (S)
+    G_syn_I_I = zeros(parameters.n,1); %conductance for pre-inhib to post-inhib (S)
+    G_syn_E_I = zeros(parameters.n,1); %conductance for pre-excit to post-inhib (S)
+
+    %Copy connectivity matrix in case of stdp changes
+    conns = network.conns; %separately update a connectivity matrix
+    
+    %Binary indices of excitatory and inhibitory neurons
+    E_bin = zeros(parameters.n,1);
+    E_bin(network.E_indices) = 1;
+    I_bin = zeros(parameters.n,1);
+    I_bin(network.I_indices) = 1;
+    
+    %Variables for STDP
+    t_spike = zeros(parameters.n,1); %vector to store the time of each neuron's last spike, for use in STDP
+    t_stdp = round(parameters.tau_stdp/parameters.dt);
+    
+    spikeMat = false(parameters.n, parameters.t_steps+1); 
+    
+    %Run through each timestep and calculate
+    for t = 1:parameters.t_steps
+        %check for spiking neurons and postsynaptic and separate into E and I
+        spikers = find(V_m >= parameters.V_th);
+        spikeMat(spikers,t) = spikers;
+        
+        t_spike(spikers) = t;
+        spikers_I = spikers(ismember(spikers,network.I_indices)); %indices of inhibitory spiking presynaptic neurons
+        spikers_E = spikers(ismember(spikers,network.E_indices)); %indices of excitatory spiking presynaptic neurons
+        %______________________________________
+        %Adjust parameters dependent on spiking
+        G_sra(spikers) = G_sra(spikers) + parameters.del_G_sra; %set SRA conductance values
+        %Synaptic conductance is stepped for postsynaptic neurons
+        %   dependent on the number of presynaptic connections, and the
+        %   current will depend on the presynaptic neuron type (E_syn_I and E_syn_E)
+        incoming_conn_E = sum(conns(spikers_E,:),1)'; %post-synaptic neuron E input counts
+        incoming_conn_I = sum(conns(spikers_I,:),1)'; %post-synaptic neuron I input counts
+        G_syn_I_E = G_syn_I_E + parameters.del_G_syn_I_E*incoming_conn_I.*E_bin;
+        G_syn_E_E = G_syn_E_E + parameters.del_G_syn_E_E*incoming_conn_E.*E_bin;
+        G_syn_I_I = G_syn_I_I + parameters.del_G_syn_I_I*incoming_conn_I.*I_bin;
+        G_syn_E_I = G_syn_E_I + parameters.del_G_syn_E_I*incoming_conn_E.*I_bin;
+        %______________________________________
+        %Calculate membrane potential using integration method
+        V_ss = ( parameters.G_in(:,t).*parameters.syn_E + G_syn_E_E.*parameters.syn_E + G_syn_E_I.*parameters.syn_E + G_syn_I_I.*parameters.syn_I + G_syn_I_E.*parameters.syn_I + parameters.G_L*parameters.E_L + G_sra*parameters.E_K )./(parameters.G_L + G_sra + G_syn_E_E + G_syn_E_I + G_syn_I_I + G_syn_I_E + parameters.G_in(:,t));
+        taueff = parameters.C_m./(parameters.G_L + G_sra + G_syn_E_E + G_syn_E_I + G_syn_I_I + G_syn_I_E + parameters.G_in(:,t));
+        V_m = V_ss + (V_m - V_ss).*exp(-parameters.dt ./taueff) + randn([parameters.n,1])*parameters.V_m_noise*sqrt(parameters.dt); %the randn portion can be removed if you'd prefer no noise
+        V_m(spikers) = parameters.V_reset; %update those that just spiked to reset
+        %______________________________________
+        %Update next step conductances
+        G_sra = G_sra*exp(-parameters.dt/parameters.tau_sra); %Spike rate adaptation conductance
+        %Synaptic conductance updated for each postsynaptic neuron by
+        %incoming connection type
+        G_syn_E_E = G_syn_E_E.*exp(-parameters.dt/parameters.tau_syn_E); %excitatory conductance update
+        G_syn_I_E = G_syn_I_E.*exp(-parameters.dt/parameters.tau_syn_I); %excitatory conductance update
+        G_syn_I_I = G_syn_I_I.*exp(-parameters.dt/parameters.tau_syn_I); %inhibitory conductance update
+        G_syn_E_I = G_syn_E_I.*exp(-parameters.dt/parameters.tau_syn_E); %inhibitory conductance update
+        %______________________________________
+        %Update connection strengths via STDP
+        pre_syn_n = sum(conns(:,spikers),2) > 0; %pre-synaptic neurons
+        post_syn_n = sum(conns(spikers,:),1) > 0; %post-synaptic neurons
+        pre_syn_t = t_spike.*pre_syn_n; %spike times of pre-synaptic neurons
+        post_syn_t = t_spike.*post_syn_n'; %spike times of post-synaptic neurons
+        t_diff_pre = t - pre_syn_t; %time diff between pre-synaptic and current
+        t_diff_post = t - post_syn_t; %time diff between post-synaptic and current
+        del_conn_pre = parameters.connectivity_gain*exp(-t_diff_pre/t_stdp);
+        del_conn_post = parameters.connectivity_gain*exp(-t_diff_post/t_stdp);
+        conns(:,spikers) = conns(:,spikers) + del_conn_pre - del_conn_post; %enhance connections of those neurons that just fired
+    end

--- a/randnet.m
+++ b/randnet.m
@@ -5,8 +5,8 @@
 
 clear all
 
-parameters.saveFlag = 0; % 1 to save simulation results
-parameters.selectPath = 1; % 1 to select save destination, 0 to save in current dir
+parameters.saveFlag = 1; % 1 to save simulation results
+parameters.selectPath = 0; % 1 to select save destination, 0 to save in current dir
 parameters.plotResults = 1; % 1 to plot basic simulation results
 
 if parameters.saveFlag & parameters.selectPath
@@ -138,7 +138,7 @@ parameters = set_depedent_parameters(parameters);
 
 
 %Save to computer
-if saveFlag == 1
+if parameters.saveFlag == 1
     save(strcat(save_path,'/parameters.mat'),'parameters')
 end
 
@@ -217,6 +217,11 @@ for ithNet = 1:parameters.nNets
         G_var(ithTest).G_syn_I_I = G_syn_I_I;
         G_var(ithTest).G_syn_E_I = G_syn_E_I;
         
+        %{
+        [V_m, conns] = ...
+                randnet_calculator_memOpt(parameters, seed, network, V_m);
+        V_m_var(ithTest).V_m = V_m;
+        %}
 
         [trialResults] = detect_PBE( V_m(network.E_indices,:)>= parameters.V_th, parameters);
         if ithTest == 1 % append trialResults struct to network results struct

--- a/randnet_param_tests.m
+++ b/randnet_param_tests.m
@@ -27,7 +27,7 @@
 %% Save Path + Load Parameters
 addpath('functions')
 
-saveFlag = 1 % 1 to save simulation results
+saveFlag = 0 % 1 to save simulation results
 selectSavePath = 0; % 1 to select save destination, 0 to save in results dir
 selectLoadPath = 1; % 1 to select load source, 0 to load from results dir
 plotResults = 1; % 1 to plot basic simulation results
@@ -67,7 +67,7 @@ parameters.max_avg_length = inf;
 
 % Simulation duration
 %parameters.t_max = 10;
-parameters.t_max = 20;
+parameters.t_max = 60;
 
 % __Necessary to override the loaded parameters__ %
 parameters.saveFlag = saveFlag;
@@ -85,7 +85,7 @@ end
 %% Set Up Grid Search Parameters
 
 %Test parameters
-num_nets = 10;
+num_nets = 4;
 % num_nets = 4;
 num_inits = 1;
 test_n = 25; % Number of parameters to test (each)

--- a/test/test_randnet_calculator.m
+++ b/test/test_randnet_calculator.m
@@ -1,0 +1,117 @@
+% Tests that randnet_calculator and randnet_calculator_memOpt produce 
+% identical results
+
+
+%% Initialize parameters
+
+% Network structure parameters
+parameters.n = 500; %number of neurons
+parameters.clusters = 10; % Number of clusters in the network
+parameters.mnc = 2; % mean number of clusters each neuron is a member of
+
+% Time
+parameters.t_max = 1; %maximum amount of time (s)
+parameters.dt = 0.1*10^(-3); %timestep (s)
+
+% Basic model parameters
+parameters.tau_syn_E = 10*10^(-3); % Exc. synaptic decay time constant (s) PF19=50ms, HF18=10ms for figs 7-8 and longer for earlier figs
+parameters.tau_syn_I = 2*10^(-3);  % Inh. synaptic decay time constant (s) PF19=5ms,  HF18=10ms for figs 7-8 and for earlier figs
+parameters.tau_stdp = 5*10^(-3); %STDP time constant (s)                 
+parameters.E_K = -80*10^(-3); %potassium reversal potential (V) %-75 or -80 mV
+parameters.E_L = -70*10^(-3); %leak reversal potential (V) %-60 - -70 mV range
+parameters.G_L = 25*10^(-9); %leak conductance (S) %10 - 30 nS range
+parameters.C_m = 0.4*10^(-9); %total membrane capacitance (F) %Huge range from 0.1 - 100 pF
+parameters.V_m_noise = 0.0*10^(-3); % 10^(-4); %magnitude of noise to use in membrane potential simulation (V)
+parameters.V_th = -50*10^(-3); %threshold membrane potential (V)
+parameters.V_reset = -70*10^(-3); %reset membrane potential (V)
+parameters.V_syn_E = 0; %synaptic reversal potential (excitatory)
+parameters.V_syn_I = -70*10^(-3); %synaptic reversal potential (inhibitory) %generally -70 pr -80 mV
+
+% Recurrent connection strengths
+parameters.del_G_syn_E_E = 750*10^(-12); %synaptic conductance step following spike (S)
+parameters.del_G_syn_I_I = 0; %1.4*del_G_syn_E_E; %synaptic conductance step following spike (S)
+parameters.del_G_syn_E_I = 500*10^(-12); %synaptic conductance step following spike (S)
+parameters.del_G_syn_I_E = 500*10^(-12); %synaptic conductance step following spike (S)
+
+% SRA parameters
+parameters.del_G_sra = 330e-09; %spike rate adaptation conductance step following spike %ranges from 1-200 *10^(-9) (S)
+parameters.tau_sra = 30*10^(-3); %spike rate adaptation time constant (s)
+
+% STDP parameters
+parameters.connectivity_gain = 0; %0.005; %amount to increase or decrease connectivity by with each spike (more at the range of 0.002-0.005)
+
+% Input parameters:
+% Poisson input
+parameters.usePoisson = 1; % 1 to use poisson spike inputs, 0 for randn() input
+parameters.rG = 1000; % input spiking rate, if using poisson inputs
+parameters.W_gin = 750*10^-12; % increase in conductance, if using poisson inputs
+
+% Network connection parameters
+parameters.conn_prob = 0.08; %set a total desired connection probability
+parameters.p_E = 0.75; %probability of an excitatory neuron
+parameters.include_all = 1; % if a neuron is not in any cluster, take cluster membership from a highly connected neuron
+parameters.global_inhib = 1; % if 1, I-cells are not clustered and have connection probability p_I
+parameters.p_I = 0.5; % probability of an I cell connecting to any other cell
+
+% Number of trials per net to run
+parameters.nTrials = 1; % How many tests of different initializations to run
+parameters.nNets = 1; % How many networks to run
+
+
+%% __set/update Dependent Parameters__ %%
+parameters = set_depedent_parameters(parameters);
+
+
+%% Generete ith network structure
+ithNet = 1;
+network = create_clusters(parameters, 'seed', ithNet, 'include_all', parameters.include_all, 'global_inhib', parameters.global_inhib);
+
+
+%% Create input conductance variable
+if parameters.usePoisson
+    G_in = single(zeros(parameters.n, parameters.t_steps+1));
+    %G_in = zeros(parameters.n, parameters.t_steps+1);
+    for k = 2:(parameters.t_steps+1)
+        G_in(:,k) = G_in(:,k-1)*exp(-parameters.dt/parameters.tau_syn_E);
+        G_in(:,k) = G_in(:,k) + parameters.W_gin * [rand(parameters.n, 1) < (parameters.dt*parameters.rG)];
+    end
+else
+    G_in = (parameters.G_std*randn(parameters.n,parameters.t_steps+1))+parameters.G_mean;
+    G_in(G_in<0) = 0;
+end
+parameters.('G_in') = G_in;
+
+
+%% Create Storage Variables
+V_m = zeros(parameters.n,parameters.t_steps+1); %membrane potential for each neuron at each timestep
+V_m(:,1) = parameters.V_reset + randn([parameters.n,1])*(10^(-3))*sqrt(parameters.dt); %set all neurons to baseline reset membrane potential with added noise
+seed = 1;
+
+
+%% Run model
+
+[V_m1] = randnet_calculator(parameters, seed, network, V_m);
+spikes1 = logical(V_m1>=parameters.V_th);
+
+[spikes2] = randnet_calculator_memOpt(parameters, seed, network, V_m(:,1) );
+        
+
+%% Test
+
+assert( isequal(spikes1, spikes2), 'Not Equal' )
+isequal(spikes1, spikes2)
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
1) Create randnet_calculator_memOpt, which produces the exact spikes as randnet_calculator with lower memory usage
2) Switch parallelize_parameter_tests_2 to use randnet_calculator_memOpt and other memory-optimization changes
3) Create a test script, test_randnet_calculator, to ensure the two simulation functions produce identical spike matrices