### PR TITLE
Added Criticality Detection to Parameter Tests

### DIFF
--- a/functions/pull_avalanches.m
+++ b/functions/pull_avalanches.m
@@ -1,0 +1,30 @@
+function [event_lengths, event_counts] = pull_avalanches(used_spikes_mat)
+    %This function is used to pull out segments of firing from a network to
+    %then test for criticality.
+
+    event_lengths = [];
+    event_counts = [];
+    
+    [~,spikes_t] = find(used_spikes_mat);
+
+    if ~isempty(spikes_t)
+        last_start = 1;
+        last_time = 1;
+        spike_counts = 1;
+        for t_i = 2:length(spikes_t)
+            s_i = spikes_t(t_i);
+            if s_i - last_time <= 1 %check if the next spike is in the same or next time bin
+                last_time = s_i; %store the updated last time of a spike in the event
+                spike_counts = spike_counts + 1;
+            else %if the spike is not within an event timebin update parameters to store a new event
+                e_len = last_time - last_start;
+                event_lengths = [event_lengths, e_len]; %#ok<AGROW> %add the last range of spikes to the events vector
+                event_counts = [event_counts, spike_counts]; %#ok<AGROW>
+                last_start = s_i;
+                last_time = s_i;
+                spike_counts = 1;
+            end
+        end
+    end
+
+end

--- a/functions/test_chaos.m
+++ b/functions/test_chaos.m
@@ -1,6 +1,0 @@
-function [chaos_results] = test_chaos(parameters, allResults)
-    %This function is used to test network results for chaotic activity
-    
-    
-
-end

--- a/functions/test_criticality.m
+++ b/functions/test_criticality.m
@@ -1,0 +1,53 @@
+function criticality = test_criticality(avalanche_lengths, avalanche_counts)
+    %This function is used to test network results for chaotic activity
+    %Test 1: Length: # Successive time bins with no loss of activity
+    %Test 2: Size: Total # spikes during stretch of time bins with no loss 
+    %       of activity
+    %Test 3: Average Size / Length: Mean # spikes of a given duration as a 
+    %       function of duration
+    %The histograms of all of these values can be fit by power laws if the
+    %activity is an avalanche: log(xα) = αlog(x)
+    %
+    %INPUTS:
+    %   avalanche_lengths = an array of (1xN) size, where N is the number of
+    %                       events of the network spiking, containing the
+    %                       length of each avalanche sequence.
+    %   avalanche_counts = an array of (1xN) size, where N is the number of
+    %                       events of the network spiking, containing the
+    %                       number of spikes in each avalanche sequence.
+    
+    %Grab numbers of events and appropriate histogram bin numbers based on
+    %Freedman-Diaconis rule
+    N = len(avalanche_lengths); %Number of events
+    iqr_len = iqr(avalanche_lengths); %Interquartile range of lengths
+    iqr_count = iqt(avalanche_counts); %Interquartile range of counts
+    len_bin_wid = 2*iqr_len/(N^(1/3));
+    len_bins = [0:len_bin_wid:max(avalanche_lenghts)];
+    count_bin_wid = 2*iqr_count/(N^(1/3));
+    count_bins = [0:count_bin_wid:max(avalanche_counts)];
+    
+    %Grab average size of avalanche per length stats and get histogram bin
+    %numbers as above
+    [sort_ava_len, sort_ind] = sort(avalanche_lengths);
+    unique_len = unique(sort_ava_len);
+    avg_sz_per_len = zeros(size(unique_len));
+    for u_l = 1:length(unique_len)
+        %Write some code finding the average size per length
+    end
+    
+    %Grab counts per bins
+    len_num_hist = histogram(avalanche_lengths,len_bins);
+    count_num_hist = histogram(avalanche_counts,count_bins);
+    len_num_counts = len_num_hist.Values;
+    count_num_counts = count_num_hist.Values;
+    
+    %Test for linear relationships
+    
+    
+    %Set the criticality flag based on test
+    criticality = 0;
+    
+    
+    
+
+end

--- a/randnet_param_tests.m
+++ b/randnet_param_tests.m
@@ -68,10 +68,9 @@ disp('Data Imported')
 % parameters.clusters = 10; % Number of clusters in the network
 % parameters.mnc = 3; % mean number of clusters each neuron is a member of
 parameters.p_I = 0.25; %Probabilty of blanket inhibition connectivity
-
 parameters.V_m_noise = 10^(-4); %magnitude of noise
-
 parameters.G_std = 20*10^(-9);
+parameters.check_criticality = 1; %=1 if want to test network for chaos
 
 try %Ensure that E_events_only = 1
     assert(parameters.E_events_only == 1)
@@ -202,7 +201,7 @@ sprintf('Program Runtime (s) = %.2f',runTime)
 
 saveAll = 0; %Flag to save all Workspace variables after results are saved
 
-resultsMat = nan([cellfun(@length, {variedParam.range}), 4]);
+resultsMat = nan([cellfun(@length, {variedParam.range}), 5]);
 resultsStruct = struct;
 for i = 1:size(resultsMatLinear, 2)
     
@@ -227,6 +226,7 @@ frac_partic = resultsMat(nSlices{:},1);
 avg_fr = resultsMat(nSlices{:},2);
 avg_event_length = resultsMat(nSlices{:},3);
 avg_n_events = resultsMat(nSlices{:},4);
+event_criticality = resultsMat(nSlices{:},5); %Not an average value - equal to 1 if parameter set results in critical activity, and 0 if not.
 
 
 if parameters.saveFlag
@@ -324,6 +324,7 @@ else %Sequence analysis
     frac_partic_bin = frac_partic >= parameters.event_cutoff;
     avg_fr_bin = parameters.min_avg_fr <= avg_fr <= parameters.max_avg_fr;
     avg_event_length_bin = parameters.min_avg_length <= avg_event_length <= parameters.max_avg_length;
+    criticality_bin = event_criticality < 1;  %Where NOT critical. Can change to look for where it IS critical by setting == 1.
     %Store ranges for each individual criterion
     w = whos;
     for a = 1:length(w)
@@ -354,7 +355,7 @@ else %Sequence analysis
         end    
     end
     %Find where criteria matching overlaps
-    overlap = frac_partic_bin.*avg_fr_bin.*avg_event_length_bin;
+    overlap = frac_partic_bin.*avg_fr_bin.*avg_event_length_bin.*criticality_bin;
     indc_overlap = find(overlap);
     subsc_overlap = cell(size(mat_dim));
     [subsc_overlap{:}] = ind2sub(mat_dim,indc_overlap);


### PR DESCRIPTION
Added code to detect whether a parameter set results in chaotic activity.

- parallelize_parameter_tests_2: added output value of whether parameter combination resulted in chaotic activity
- pull_avalanches: new function to take binary spike matrix and pull out all potential avalanche lengths and sizes
- test_criticality: function to test criticality by looking for power laws in avalanches of activity
- randnet_param_tests: added flag to check for criticality